### PR TITLE
Davidarm dateconfig updates

### DIFF
--- a/scripts/openFileDateConfig.json
+++ b/scripts/openFileDateConfig.json
@@ -530,23 +530,6 @@
     },
     {
       "reportType": "http://linked.data.gov.au/def/georesource-report/any-other-report",
-      "calculationType": "STANDARD",
-      "calculations": [
-        {
-          "period": {
-            "years": 5,
-            "months": 0,
-            "days": 1
-          }
-        }
-      ]
-    },
-    {
-      "reportType": "http://linked.data.gov.au/def/georesource-report/any-other-report",
-      "calculationType": "CONFIDENTIAL"
-    },
-    {
-      "reportType": "http://linked.data.gov.au/def/georesource-report/any-other-report",
       "calculationType": "CONFIDENTIAL"
     },
     {
@@ -610,14 +593,6 @@
           }
         }
       ]
-    },
-    {
-      "reportType": "http://linked.data.gov.au/def/georesource-report/permit-report-final",
-      "calculationType": "IMMEDIATE"
-    },
-    {
-      "reportType": "http://linked.data.gov.au/def/georesource-report/permit-report-surrender",
-      "calculationType": "IMMEDIATE"
     },
     {
       "reportType": "http://linked.data.gov.au/def/georesource-report/water-report-other",

--- a/scripts/openFileDateConfig.json
+++ b/scripts/openFileDateConfig.json
@@ -559,7 +559,7 @@
         {
           "period": {
             "years": 5,
-            "months": 0,
+            "months": 1,
             "days": 1
           }
         }
@@ -586,6 +586,19 @@
           "period": {
             "years": 5,
             "months": 0,
+            "days": 1
+          }
+        }
+      ]
+    },
+    {
+      "reportType": "http://linked.data.gov.au/def/georesource-report/collaborative-exploration-initiative-final",
+      "calculationType": "STANDARD",
+      "calculations": [
+        {
+          "period": {
+            "years": 0,
+            "months": 6,
             "days": 1
           }
         }

--- a/scripts/openFileDateConfig.json
+++ b/scripts/openFileDateConfig.json
@@ -545,9 +545,6 @@
       "calculationType": "CONFIDENTIAL"
     },
     {
-      "calculationType": "CONFIDENTIAL"
-    },
-    {
       "reportType": "http://linked.data.gov.au/def/georesource-report/technical-report",
       "calculationType": "CONFIDENTIAL"
     },

--- a/scripts/openFileDateConfig.json
+++ b/scripts/openFileDateConfig.json
@@ -593,16 +593,7 @@
     },
     {
       "reportType": "http://linked.data.gov.au/def/georesource-report/collaborative-exploration-initiative-final",
-      "calculationType": "STANDARD",
-      "calculations": [
-        {
-          "period": {
-            "years": 0,
-            "months": 6,
-            "days": 1
-          }
-        }
-      ]
+      "calculationType": "CONFIDENTIAL"
     },
     {
       "reportType": "http://linked.data.gov.au/def/georesource-report/water-report-other",


### PR DESCRIPTION
Changes made:

-Removed duplicates and confirmed there are 66 unique templates in reporTemplates.json and 66 in openfileDate.json. Unsure of why, but duplicates appeared for:

permit-report-final
permit-report-surrender
any-other-report

-Removed formatting issue with an extra object being created with no template.

-Made collaborative-exploration template confidential

-Change calculations for permit-report-annual to 5 years, 1 month, 1 day. 