### PR TITLE
Limit MultiSelect Permit and add legacy PROD RESERV

### DIFF
--- a/scripts/reportTemplates.json
+++ b/scripts/reportTemplates.json
@@ -1,10404 +1,10404 @@
 {
-	"version": "0.6",
-	"Last updated date": "02/08/2021",
-	"Last updated by": "S Rajapakse, SRA",
-	"templates": {
-		"http://linked.data.gov.au/def/georesource-report/hydraulic-fracturing-activity-report": {
-			"steps": [
-				{
-					"title": "Lodge a Hydraulic Fracturing Activity Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"type": "component",
-							"name": "title",
-							"format": "[permit] [siteName] HYDRAULIC FRACTURING ACTIVITIES COMPLETION REPORT [title]",
-							"viewLabel": "Title of the Report",
-							"label": "STAGES/ZONES (Optional)",
-							"placeholder": "e.g Stages 1-5"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc ",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Activity Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Activity Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Activity Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Activity End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Activity End Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Activity End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Activity End Date must be greater than the Activity Start Date"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-production-information": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Petroleum Production Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[authorizedHolder] - [title] PETROLEUM PRODUCTION REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Coverage Of Report",
-							"placeholder": "e.g. ALL QUEENSLAND, BOWEN BASIN, BIG HILL PROJECT, FAIR GULLY FIELD, PL 1",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, areas of interest etc ",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-resource-and-reserves-information": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Petroleum Resources and Reserves Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[authorizedHolder] - [title] PETROLEUM RESOURCES AND RESERVES REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Coverage Of Report",
-							"placeholder": "e.g. ALL QUEENSLAND, BOWEN BASIN, BIG HILL PROJECT, FAIR GULLY FIELD, PL 1",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe fluid volumes oil and gas.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/scientific-or-technical-survey-report": {
-			"steps": [
-				{
-					"title": "Lodge a Scientific or Technical Survey Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [survey] SURVEY FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Survey End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Survey End Date must be greater than the Survey Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/seismic-survey-report-final": {
-			"steps": [
-				{
-					"title": "Lodge a Seismic Survey Report - Final",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [surveyTitle] SEISMIC SURVEY FINAL REPORT",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component",
-							"placeholder": "e.g. ATP123, 2019 Brunswick 2D seismic survey, final report"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report and its associated documents, including a summary of activities, target basin, main methods used, areas of interest etc.",
-							"type": "textArea"
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Acquisition Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Acquisition Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Acquisition Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Survey Acquisition End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Acquisition End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Survey Acquisition End Date must be greater than the Survey Acquisition Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Acquisition End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/seismic-survey-report-other": {
-			"steps": [
-				{
-					"title": "Lodge a Seismic Survey Report - Other",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [surveyTitle] SURVEY SEISMIC SURVEY OTHER ([title]) REPORT",
-							"viewLabel": "Title of the Report",
-							"label": "Type Of Activity (Optional) Report",
-							"placeholder": "e.g. Operations, Data Processing, Logistics",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report and its associated documents, including a summary of activities, target basin, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Survey End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Survey End Date must be greater than the Survey Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/seismic-survey-report-reprocessing": {
-			"steps": [
-				{
-					"title": "Lodge a Seismic Survey Report - Reprocessing",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"type": "component",
-							"format": "[permit] [operator] - [surveyTitle] SEISMIC REPROCESSING REPORT [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. ATP123, 2019 Brunswick 2D seismic survey, reprocessing report"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report and its associated documents, source surveys, including a summary of activities, target basin, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Reprocessing Commencement Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Reprocessing Commencement Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Reprocessing Commencement Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Reprocessing Completion Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Reprocessing Completion Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Reprocessing Completion Date must be greater than the Reprocessing Commencement Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Reprocessing Completion Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/well-completion-report": {
-			"steps": [
-				{
-					"title": "Lodge a Well or Bore Completion Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"type": "component",
-							"format": "[permit] [operator] [siteName] WELL COMPLETION REPORT",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "PL123, well name, well completion report"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the results of the drilling, methods used, target basins.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Spud Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Spud Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Spud Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Rig Release Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Rig Release Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Rig Release Date must be greater than the Spud Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Rig Release Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/well-production-testing-report": {
-			"steps": [
-				{
-					"title": "Lodge a Well Production Testing Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [siteName] - WELL PRODUCTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"type": "component",
-							"label": "Title of the Report"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea"
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true,
-							"isMultiSelect": true
-						},
-						{
-							"name": "startDate",
-							"label": "Testing Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Testing Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Testing Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Testing End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Testing End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Testing End Date must be greater than the Testing Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Testing End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/well-or-bore-abandonment-report": {
-			"steps": [
-				{
-					"title": "Lodge a Well or Bore Abandonment Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [siteName] WELL ABANDONMENT REPORT",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component",
-							"placeholder": "PL123, well name, well abandonment report"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the results of the drilling, methods used, target basins.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Activity Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Activity Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Activity Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Activity End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Activity End Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Activity End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Activity End Date must be greater than the Activity Start Date"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-annual": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Annual Activity (EPC,EPM,MDL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] ANNUAL ACTIVITY REPORT FOR PERIOD ENDING [endDate] ",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report for an exploration or development permit (EPC, EPM, MDL) including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-final": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Final (End of Tenure)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] FINAL REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the final report where tenure has ended without grant of an overlying higher tenure including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-partial-relinquishment": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Partial Relinquishment (End of Tenure)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] PARTIAL RELINQUISHMENT REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-partial-relinquishment-higher-tenure": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Partial Relinquishment (Grant of higher tenure)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] PARTIAL RELINQUISHMENT REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-surrender": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Surrender (End of Tenure)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the surrender report where tenure has ended without grant of an overlying higher tenure including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-annual": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Annual (ATP/PL/PPL/PFL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] ANNUAL REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. PPL123, Project Name, annual report for period ending 28-04-2020",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-end-tenure": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Final (ATP/PL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] FINAL REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. ATP123, Project Name, final report for period ending 28-04-2020",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-relinquishment": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Relinquishment (ATP/PL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] PARTIAL RELINQUISHMENT REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. ATP123, Project Name, relinquishment report for period ending 28-04-2020",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-surrender": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Surrender (ATP/PL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. ATP123, Project Name, surrender report for period ending 28-04-2020",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pipeline-report-surrender": {
-			"steps": [
-				{
-					"title": "Petroleum Report - Pipeline Surrender (PPL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. PPL123, Project Name, surrender report for period ending 28-04-2020",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, maintenance, decommissioning, etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-end-authority": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - End of Authority (DAA/PSL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] FINAL REPORT FOR PERIOD ENDING  [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. DAA123, Project Name, end of authority report for period ending 28-04-2020",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
-							"type": "textArea"
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-acquisition": {
-			"steps": [
-				{
-					"title": "Lodge a Geophysical Survey Report - Acquisition",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Survey End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Survey End Date must be greater than the Survey Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-final": {
-			"steps": [
-				{
-					"title": "Lodge a Geophysical Survey Report - Final",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[survey] SURVEY [startDate] TO [endDate] - [title] FINAL REPORT ",
-							"viewLabel": "Title of the Report",
-							"label": "Type Of Activity (Optional)",
-							"placeholder": "e.g. Operations, Data Processing, Logistics",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Acquisition Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Acquisition Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Acquisition Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Survey Acquisition End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Acquisition End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Survey Acquisition End Date must be greater than the Survey Acquistion Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Acquisition End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-logistics": {
-			"steps": [
-				{
-					"title": "Lodge a Geophysical Survey Report - Logistics",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Survey End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Survey End Date must be greater than the Survey Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geothermal-report-annual-reserves": {
-			"steps": [
-				{
-					"title": "Lodge a Geothermal Report - Annual Reserves",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [authorizedHolder] - [title] GEOTHERMAL ANNUAL RESERVES REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geothermal-report-annual": {
-			"steps": [
-				{
-					"title": "Lodge a Geothermal Report - Annual",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] GEOTHERMAL ANNUAL ACTIVITY REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geothermal-report-injection": {
-			"steps": [
-				{
-					"title": "Lodge a Geothermal Report - Injection",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] GEOTHERMAL INJECTION REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geothermal-report-injection-testing": {
-			"steps": [
-				{
-					"title": "Lodge a Geothermal Report - Injection Testing",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [siteName] - GEOTHERMAL INJECTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true,
-							"isMultiSelect": true
-						},
-						{
-							"name": "startDate",
-							"label": "Testing Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Testing Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Testing Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Testing End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Testing End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Testing End Date must be greater than the Testing Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Testing End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geothermal-report-production": {
-			"steps": [
-				{
-					"title": "Lodge a Geothermal Report - Production",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[authorizedHolder] - [title] GEOTHERMAL PRODUCTION REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"placeholder": "e.g. ALL QUEENSLAND, BOWEN BASIN, BIG HILL PROJECT, FAIR GULLY FIELD, PL 1",
-							"label": "Coverage Of Report",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geothermal-report-production-testing": {
-			"steps": [
-				{
-					"title": "Lodge a Geothermal Report - Production Testing",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [siteName] - GEOTHERMAL PRODUCTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true,
-							"isMultiSelect": true
-						},
-						{
-							"name": "startDate",
-							"label": "Testing Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Testing Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Testing Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Testing End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Testing End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Testing End Date must be greater than the Testing Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Testing End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/greenhouse-gas-report-injection": {
-			"steps": [
-				{
-					"title": "Lodge a Greenhouse Gas Report - Injection",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] - [siteName] - GEOTHERMAL PRODUCTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true,
-							"isMultiSelect": true
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/greenhouse-gas-report-storage-capacity": {
-			"steps": [
-				{
-					"title": "Lodge a Greenhouse Gas Report - Storage Capacity",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] GREENHOUSE GAS STORAGE CAPACITY REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/greenhouse-gas-report-storage-injection": {
-			"steps": [
-				{
-					"title": "Lodge a Greenhouse Gas Report - Storage Injection",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] GREENHOUSE GAS STORAGE INJECTION REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/mine-plan-lodgement": {
-			"steps": [
-				{
-					"title": "Lodge a Mine Working Plan",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] MINE PLAN LODGEMENT AS AT [reportDate]",
-							"viewLabel": "Title of the Report",
-							"placeholder": "e.g. Cannington Mine",
-							"label": "Mine Name",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/survey-plan": {
-			"steps": [
-				{
-					"title": "Lodge a Survey plan",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "What is in the title plate of the plan? e.g. PWL of Boonah 222 or Survey of Mining Lease 222",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": false,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": false,
-							"isMultiSelect": true
-						},
-						{
-							"name": "startDate",
-							"label": "Survey Completion Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Survey Completion Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Survey Completion Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Signature Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Signature Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Signature Date must be greater than the Survey Completion Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Signature Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-final-relinquishment": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Final Relinquishment (MDL)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "e.g. EPM123, Project Name, final relinquishment report for period ending 28-04-2020",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-mineral-associated-water": {
-			"steps": [
-				{
-					"title": "Lodge a Water Report - Mineral Associated Water",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] MINERAL ASSOCIATED WATER TAKE REPORT FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project/Mine Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine, Cannington Mine",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the volume of water taken and from which basin taken.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-cumulative-water-production": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Cumulative Water Production",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "PL123, cumulative water production report for period ending 28-04-2020",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe fluid volumes oil and gas.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-field-information": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Field Information",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-infrastructure": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Infrastructure",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-non-associated-water": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Non-Associated Water",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] PETROLEUM NON-ASSOCIATED WATER TAKE REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/water-report-performance-review": {
-			"steps": [
-				{
-					"title": "Lodge a Water Report - Performance Review",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] WATER PERFORMANCE REVIEW FOR PERIOD [startDate] TO [endDate]",
-							"viewLabel": "Title of the Report",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine, Cannington Mine",
-							"label": "Project/Mine Name",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"End Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The End Date must be greater than the Start Date"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "waterLicenceNumber",
-							"label": "Water Licence Number",
-							"subLabelAtTop": "Please enter the Water Licence Number",
-							"type": "text",
-							"value": "",
-							"min": 5,
-							"max": 256,
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Water Licence is required"
-										]
-									},
-									{
-										"name": "min",
-										"params": [
-											1,
-											"The Water Licence Number cannot be less than 1 character"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Water Licence Number can not be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pa-21A": {
-			"steps": [
-				{
-					"title": "Lodge a PA-21A Notice of Intention to carry out seismic survey or scientific or technical survey",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title] NOTICE OF INTENT TO CARRY OUT SEISMIC SURVEY OR SCIENTIFIC OR TECHINCAL SURVEY (PA-21A) [reportDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Survey Name",
-							"placeholder": "e.g. New Royal 3D, Bennett 2D, Cloncurry Airborne Geophysical Survey",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the intended survey including the method, target basins or features, planned activities, the extent of the survey, etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pa-22A": {
-			"steps": [
-				{
-					"title": "Lodge a PA-22A Notice of Completion of seismic survey or scientific or technical survey",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[surveyTitle] NOTICE OF COMPLETION OF SEISMIC SURVEY OR SCIENTIFIC OR TECHINCAL SURVEY (PA-22A) [reportDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "e.g. ATP123, 2019 Brunswick 2D seismic survey, notice of completion",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the survey, including methods, activities, target basin, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pm-1-2013": {
-			"steps": [
-				{
-					"title": "Lodge a PM 1/2013 Notification of geophysical survey",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title] - NOTICE OF INTENT TO CARRY OUT GEOPHYSICAL SURVEY (PM 1-2013) [reportDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Survey Name",
-							"placeholder": "e.g. New Royal 3D, Bennett 2D, Cloncurry Airborne Geophysical Survey",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pa-42": {
-			"steps": [
-				{
-					"title": "Lodge a PA-42 Notice of intention to convert a petroleum well to a water observation bore or water supply bore",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[siteName]  NOTICE OF INTENTION TO CONVERT A PETROLEUM WELL TO A WATER OBSERVATION BORE OR WATER SUPPLY BORE (PA-42) [reportDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/wra-05A": {
-			"steps": [
-				{
-					"title": "Lodge a WRA-05A Notice of completion of conversion of petroleum well to water supply bore or water observation bore",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [operator] [siteName]  NOTICE OF COMPLETION OF CONVERSION OF PETROLEUM WELL TO WATER SUPPLY BORE OR WATER OBSERVATION BORE (WRA-05A) - [reportDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/mmol-44": {
-			"steps": [
-				{
-					"title": "Lodge a MMOL-44 Notice of decommissioning a well, water observation bore, water monitoring bore or water supply bore",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[siteName] NOTICE OF DECOMMISION (MMOL-44) [reportDate]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true,
-							"isMultiSelect": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pggd-01": {
-			"steps": [
-				{
-					"title": "PGGD-01 Notice of intention to drill a petroleum well or bore",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "boreholeCreate",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Upload Notice of Intention",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "Notice of Intention",
-							"type": "component",
-							"values": {
-								"earthScienceData": {
-									"readOnly": true,
-									"value": "http://linked.data.gov.au/def/earth-science-data-category/drilling-engineering"
-								},
-								"title": {
-									"readOnly": true,
-									"value": "Notice of Intention"
-								},
-								"description": {
-									"readOnly": true,
-									"value": "Notice of Intention"
-								}
-							}
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pggd-02": {
-			"steps": [
-				{
-					"title": "PGGD-02 Notice of completion, alteration or abandonment of a petroleum well or bore",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "boreholeAlteration",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Upload Notice of Completion, Alteration or Abandonment",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "Notice of Completion, Alteration or Abandonment",
-							"type": "component",
-							"values": {
-								"earthScienceData": {
-									"readOnly": true,
-									"value": "http://linked.data.gov.au/def/earth-science-data-category/drilling-engineering"
-								},
-								"title": {
-									"readOnly": true,
-									"value": "Notice of Completion, Alteration or Abandonment"
-								},
-								"description": {
-									"readOnly": true,
-									"value": ""
-								}
-							}
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pggd-03": {
-			"steps": [
-				{
-					"title": "PGGD-03 Notice of intention to carry out hydraulic fracturing activities",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "boreholeFracturing",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Upload Proposed Fluid Composition",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "Proposed Fluid Composition",
-							"isRequired": true,
-							"type": "component",
-							"values": {
-								"earthScienceData": {
-									"readOnly": true,
-									"value": "http://linked.data.gov.au/def/earth-science-data-category/reservoir-engineering"
-								},
-								"title": {
-									"readOnly": true,
-									"value": "Proposed Fluid Composition"
-								},
-								"description": {
-									"readOnly": true,
-									"value": "Proposed Fluid Composition"
-								}
-							}
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/pggd-04": {
-			"steps": [
-				{
-					"title": "PGGD-04 Notice of completion of hydraulic fracturing activities",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "boreholeFracturingCompletion",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Upload Actual Fluid Composition",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "Actual Fluid Composition",
-							"infoText": "If 'Hydraulic fracturing abandoned' or 'Hydraulic fracturing related events' is selected then 'Actual Fluid Composition' document is not required to be lodged.",
-							"type": "component",
-							"isRequired": true,
-							"values": {
-								"earthScienceData": {
-									"readOnly": true,
-									"value": "http://linked.data.gov.au/def/earth-science-data-category/reservoir-engineering"
-								},
-								"title": {
-									"readOnly": true,
-									"value": "Actual Fluid Composition"
-								},
-								"description": {
-									"readOnly": true,
-									"value": "Actual Fluid Composition"
-								}
-							}
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/any-other-report": {
-			"steps": [
-				{
-					"title": "Lodge a Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title of the Report",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": false,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "survey",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "nullable",
-										"params": [
-											""
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "nullable",
-										"params": [
-											""
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/collaborative-exploration-initiative-proposals": {
-			"steps": [
-				{
-					"title": "Lodge a Collaborative Exploration Initiative Proposal",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "COLLABORATIVE EXPLORATION INITIATIVE [title] - [permit] PROPOSAL",
-							"viewLabel": "Title of the Report",
-							"label": "ROUND # - CEI# PROJECT NAME - CEI ACTIVITY",
-							"placeholder": "e.g. Round 2 - CEI0027 ERNEST HENRY SOUTH PROJECT - MIMDAS SURVEY",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Provide a summary of the initiative, collaboration and proposed activity for the project",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this proposal",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Proposal Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Proposal Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "survey",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "borehole",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/collaborative-exploration-initiative-final": {
-			"steps": [
-				{
-					"title": "Lodge a Final Report for a Collaborative Exploration Initiative",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "COLLABORATIVE EXPLORATION INITIATIVE [title] - [permit] FINAL REPORT",
-							"viewLabel": "Title of the Report",
-							"label": "ROUND # - CEI# PROJECT NAME - CEI ACTIVITY",
-							"placeholder": "e.g. Round 2 : CEI0027 ERNEST HENRY SOUTH PROJECT - MIMDAS SURVEY",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Provide a summary of the initiative, collaboration and proposed activity for the project",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "survey",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "borehole",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/collaborative-drilling-initiative-final": {
-			"steps": [
-				{
-					"title": "Lodge a Final Report for a Collaborative Drilling Initiative",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Project name, collaborative drilling initiative final report",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Provide a summary of the initiative, collaboration and proposed activity for the project",
-							"type": "textArea"
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "survey",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "borehole",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/commissioned-industry-study-or-report": {
-			"steps": [
-				{
-					"title": "Lodge a Commissioned Industry Study or Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc ",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "survey",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/departmental-drilling": {
-			"steps": [
-				{
-					"title": "Lodge a Departmental Drilling Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the results of the drilling, methods used, and target basins, formations, or rock units",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": true
-						},
-						{
-							"type": "calender",
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geological-survey-of-queensland-publication": {
-			"steps": [
-				{
-					"title": "Lodge a Geological Survey of Queensland Publication",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Publication",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the publication and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc ",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this publication",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Publication Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/geological-survey-of-queensland-record": {
-			"steps": [
-				{
-					"title": "Lodge a Geological Survey of Queensland Record",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "GSQ RECORD [title]",
-							"viewLabel": "Title of the Report",
-							"label": "Year - Volume Number - Title",
-							"placeholder": "e.g. 2021 - VOLUME 01 - Summary of Results NWQ geochemistry sampling campaign",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this record",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-other": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Other",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "e.g  Queensland Government Mining Journal (QGMJ), Vol. 116, No. 3, 2018",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": false
-						},
-						{
-							"type": "calender",
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/petroleum-report-other": {
-			"steps": [
-				{
-					"title": "Lodge a Petroleum Report - Other",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": false
-						},
-						{
-							"type": "calender",
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/presentation": {
-			"steps": [
-				{
-					"title": "Lodge a Presentation",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Presentation",
-							"placeholder": "e.g  Queensland Government Mining Journal (QGMJ), Vol. 116, No. 3, 2018",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the presentation, including a summary of significant results or messages, conclusions and any areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this presentation",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/queensland-government-mining-journal": {
-			"steps": [
-				{
-					"title": "Lodge a Queensland Government Mining Journal",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents and key topics of the journal and its component articles.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/technical-report": {
-			"steps": [
-				{
-					"title": "Lodge a Technical Report",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"readOnly": true,
-							"label": "Title of the Report",
-							"placeholder": "Project name, technical report, purpose",
-							"type": "component"
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": false,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "survey",
-							"isRequired": false
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "nullable",
-										"params": [
-											""
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "calender",
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "nullable",
-										"params": [
-											""
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": false
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/water-report-other": {
-			"steps": [
-				{
-					"title": "Lodge a Water Report - Other",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[title]",
-							"viewLabel": "Title of the Report",
-							"label": "Title of the Report",
-							"placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": false,
-							"populateOwner": false
-						},
-						{
-							"type": "text",
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							},
-							"subLabelAtTop": "Please enter the name of the person who has authored this report"
-						},
-						{
-							"type": "component",
-							"name": "borehole",
-							"isRequired": false
-						},
-						{
-							"type": "calender",
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "nullable",
-										"params": [
-											""
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"type": "calender",
-							"label": "Report Period End Date",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "nullable",
-										"params": [
-											""
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is invalid"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "text",
-							"name": "waterLicenceNumber",
-							"label": "Water Licence Number",
-							"subLabelAtTop": "Please enter the Water Licence Number",
-							"value": "",
-							"min": 5,
-							"max": 256,
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Water Licence is required"
-										]
-									},
-									{
-										"name": "min",
-										"params": [
-											1,
-											"The Water Licence Number cannot be less than 1 character"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Water Licence Number can not be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						}
-					]
-				},
-				{
-					"name": "Document Uploads",
-					"title": "Documents and Data",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-annual-ml": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Annual Activity (ML)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] ANNUAL ACTIVITY REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the report for a coal or oil shale mining lease including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-final-higher-tenure": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Final (Grant of higher tenure)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] FINAL REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the final report where higher tenure has been granted for the overlying area including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		},
-		"http://linked.data.gov.au/def/georesource-report/permit-report-surrender-higher-tenure": {
-			"steps": [
-				{
-					"title": "Lodge a Coal or Mineral Permit Report - Surrender (Grant of higher tenure)",
-					"name": "Report Details",
-					"inputs": [
-						{
-							"name": "title",
-							"format": "[permit] [title] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
-							"viewLabel": "Title of the Report",
-							"label": "Project Name",
-							"placeholder": "e.g. Norwich Park, Monto West, Ernestine",
-							"type": "component",
-							"isRequired": false
-						},
-						{
-							"name": "alias",
-							"label": "Aliases",
-							"type": "component",
-							"readOnly": true
-						},
-						{
-							"name": "description",
-							"viewLabel": "Description",
-							"label": "Report Description",
-							"placeholder": "Describe a summary of the surrender report where higher tenure has been granted for the overlying area including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
-							"type": "textArea",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "matches",
-										"isComplex": true,
-										"params": [
-											"/^[0-9A-Za-z- ./,]+$/",
-											"Description cannot include non-standard characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "permit",
-							"isRequired": true,
-							"populateOwner": true
-						},
-						{
-							"name": "reportAuthor",
-							"label": "Report Author",
-							"subLabelAtTop": "Please enter the name of the person who has authored this report",
-							"type": "text",
-							"validations": {
-								"type": "string",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Author is required"
-										]
-									},
-									{
-										"name": "max",
-										"params": [
-											256,
-											"The Report Author cannot be more than 256 characters"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "startDate",
-							"label": "Report Period Start Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period Start Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"name": "endDate",
-							"label": "Report Period End Date",
-							"type": "calender",
-							"validations": {
-								"type": "date",
-								"rules": [
-									{
-										"name": "required",
-										"params": [
-											"Report Period End Date is required"
-										]
-									},
-									{
-										"name": "min",
-										"isComplex": true,
-										"params": [
-											"yup.ref('startDate')",
-											"The Report Period End Date must be greater than the Report Period Start Date"
-										]
-									},
-									{
-										"name": "typeError",
-										"params": [
-											"Report Period End Date is required"
-										]
-									}
-								]
-							}
-						},
-						{
-							"type": "component",
-							"name": "commodity",
-							"isRequired": true
-						},
-						{
-							"type": "component",
-							"name": "earthScienceData",
-							"isRequired": true
-						},
-						{
-							"name": "detail",
-							"label": "Details",
-							"type": "component",
-							"readOnly": true
-						}
-					]
-				},
-				{
-					"title": "Documents and Data",
-					"name": "Document Uploads",
-					"inputs": [
-						{
-							"name": "associatedDocuments",
-							"label": "associated document",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "reportingTemplateDocuments",
-							"type": "component",
-							"isRequired": true
-						},
-						{
-							"name": "spatialDocuments",
-							"type": "component",
-							"isRequired": false
-						}
-					]
-				},
-				{
-					"title": "Review and Submit",
-					"name": "Review & Submit",
-					"inputs": [
-						{
-							"name": "review",
-							"type": "component",
-							"isRequired": true
-						}
-					]
-				}
-			]
-		}
-	}
+  "version": "0.7",
+  "Last updated date": "20/08/2021",
+  "Last updated by": "V Kelly, GSQ",
+  "templates": {
+    "http://linked.data.gov.au/def/georesource-report/hydraulic-fracturing-activity-report": {
+      "steps": [
+        {
+          "title": "Lodge a Hydraulic Fracturing Activity Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "type": "component",
+              "name": "title",
+              "format": "[permit] [siteName] HYDRAULIC FRACTURING ACTIVITIES COMPLETION REPORT [title]",
+              "viewLabel": "Title of the Report",
+              "label": "STAGES/ZONES (Optional)",
+              "placeholder": "e.g Stages 1-5"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc ",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Activity Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Activity Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Activity Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Activity End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Activity End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Activity End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Activity End Date must be greater than the Activity Start Date"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-production-information": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Petroleum Production Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[authorizedHolder] - [title] PETROLEUM PRODUCTION REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Coverage Of Report",
+              "placeholder": "e.g. ALL QUEENSLAND, BOWEN BASIN, BIG HILL PROJECT, FAIR GULLY FIELD, PL 1",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, areas of interest etc ",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-resource-and-reserves-information": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Petroleum Resources and Reserves Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[authorizedHolder] - [title] PETROLEUM RESOURCES AND RESERVES REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Coverage Of Report",
+              "placeholder": "e.g. ALL QUEENSLAND, BOWEN BASIN, BIG HILL PROJECT, FAIR GULLY FIELD, PL 1",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe fluid volumes oil and gas.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/scientific-or-technical-survey-report": {
+      "steps": [
+        {
+          "title": "Lodge a Scientific or Technical Survey Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [survey] SURVEY FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Survey End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Survey End Date must be greater than the Survey Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/seismic-survey-report-final": {
+      "steps": [
+        {
+          "title": "Lodge a Seismic Survey Report - Final",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [surveyTitle] SEISMIC SURVEY FINAL REPORT",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component",
+              "placeholder": "e.g. ATP123, 2019 Brunswick 2D seismic survey, final report"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report and its associated documents, including a summary of activities, target basin, main methods used, areas of interest etc.",
+              "type": "textArea"
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Acquisition Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Acquisition Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Acquisition Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Survey Acquisition End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Acquisition End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Survey Acquisition End Date must be greater than the Survey Acquisition Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Acquisition End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/seismic-survey-report-other": {
+      "steps": [
+        {
+          "title": "Lodge a Seismic Survey Report - Other",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [surveyTitle] SURVEY SEISMIC SURVEY OTHER ([title]) REPORT",
+              "viewLabel": "Title of the Report",
+              "label": "Type Of Activity (Optional) Report",
+              "placeholder": "e.g. Operations, Data Processing, Logistics",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report and its associated documents, including a summary of activities, target basin, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Survey End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Survey End Date must be greater than the Survey Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/seismic-survey-report-reprocessing": {
+      "steps": [
+        {
+          "title": "Lodge a Seismic Survey Report - Reprocessing",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "type": "component",
+              "format": "[permit] [operator] - [surveyTitle] SEISMIC REPROCESSING REPORT [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. ATP123, 2019 Brunswick 2D seismic survey, reprocessing report"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report and its associated documents, source surveys, including a summary of activities, target basin, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Reprocessing Commencement Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Reprocessing Commencement Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Reprocessing Commencement Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Reprocessing Completion Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Reprocessing Completion Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Reprocessing Completion Date must be greater than the Reprocessing Commencement Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Reprocessing Completion Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/well-completion-report": {
+      "steps": [
+        {
+          "title": "Lodge a Well or Bore Completion Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "type": "component",
+              "format": "[permit] [operator] [siteName] WELL COMPLETION REPORT",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "PL123, well name, well completion report"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the results of the drilling, methods used, target basins.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Spud Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Spud Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Spud Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Rig Release Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Rig Release Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Rig Release Date must be greater than the Spud Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Rig Release Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/well-production-testing-report": {
+      "steps": [
+        {
+          "title": "Lodge a Well Production Testing Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [siteName] - WELL PRODUCTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "type": "component",
+              "label": "Title of the Report"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea"
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true,
+              "isMultiSelect": true
+            },
+            {
+              "name": "startDate",
+              "label": "Testing Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Testing Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Testing Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Testing End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Testing End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Testing End Date must be greater than the Testing Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Testing End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/well-or-bore-abandonment-report": {
+      "steps": [
+        {
+          "title": "Lodge a Well or Bore Abandonment Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [siteName] WELL ABANDONMENT REPORT",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component",
+              "placeholder": "PL123, well name, well abandonment report"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the results of the drilling, methods used, target basins.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Activity Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Activity Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Activity Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Activity End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Activity End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Activity End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Activity End Date must be greater than the Activity Start Date"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-annual": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Annual Activity (EPC,EPM,MDL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] ANNUAL ACTIVITY REPORT FOR PERIOD ENDING [endDate] ",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report for an exploration or development permit (EPC, EPM, MDL) including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-final": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Final (End of Tenure)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] FINAL REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the final report where tenure has ended without grant of an overlying higher tenure including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-partial-relinquishment": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Partial Relinquishment (End of Tenure)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] PARTIAL RELINQUISHMENT REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-partial-relinquishment-higher-tenure": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Partial Relinquishment (Grant of higher tenure)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] PARTIAL RELINQUISHMENT REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-surrender": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Surrender (End of Tenure)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the surrender report where tenure has ended without grant of an overlying higher tenure including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-annual": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Annual (ATP/PL/PPL/PFL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] ANNUAL REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. PPL123, Project Name, annual report for period ending 28-04-2020",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-end-tenure": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Final (ATP/PL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] FINAL REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. ATP123, Project Name, final report for period ending 28-04-2020",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-relinquishment": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Relinquishment (ATP/PL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] PARTIAL RELINQUISHMENT REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. ATP123, Project Name, relinquishment report for period ending 28-04-2020",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-surrender": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Surrender (ATP/PL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. ATP123, Project Name, surrender report for period ending 28-04-2020",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pipeline-report-surrender": {
+      "steps": [
+        {
+          "title": "Petroleum Report - Pipeline Surrender (PPL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. PPL123, Project Name, surrender report for period ending 28-04-2020",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, maintenance, decommissioning, etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-end-authority": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - End of Authority (DAA/PSL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] FINAL REPORT FOR PERIOD ENDING  [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. DAA123, Project Name, end of authority report for period ending 28-04-2020",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, hydrocarbon occurrences, main methods used, target areas of interest etc.",
+              "type": "textArea"
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-acquisition": {
+      "steps": [
+        {
+          "title": "Lodge a Geophysical Survey Report - Acquisition",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Survey End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Survey End Date must be greater than the Survey Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-final": {
+      "steps": [
+        {
+          "title": "Lodge a Geophysical Survey Report - Final",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[survey] SURVEY [startDate] TO [endDate] - [title] FINAL REPORT ",
+              "viewLabel": "Title of the Report",
+              "label": "Type Of Activity (Optional)",
+              "placeholder": "e.g. Operations, Data Processing, Logistics",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Acquisition Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Acquisition Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Acquisition Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Survey Acquisition End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Acquisition End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Survey Acquisition End Date must be greater than the Survey Acquistion Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Acquisition End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-logistics": {
+      "steps": [
+        {
+          "title": "Lodge a Geophysical Survey Report - Logistics",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Survey End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Survey End Date must be greater than the Survey Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geothermal-report-annual-reserves": {
+      "steps": [
+        {
+          "title": "Lodge a Geothermal Report - Annual Reserves",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [authorizedHolder] - [title] GEOTHERMAL ANNUAL RESERVES REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geothermal-report-annual": {
+      "steps": [
+        {
+          "title": "Lodge a Geothermal Report - Annual",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] GEOTHERMAL ANNUAL ACTIVITY REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geothermal-report-injection": {
+      "steps": [
+        {
+          "title": "Lodge a Geothermal Report - Injection",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] GEOTHERMAL INJECTION REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geothermal-report-injection-testing": {
+      "steps": [
+        {
+          "title": "Lodge a Geothermal Report - Injection Testing",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [siteName] - GEOTHERMAL INJECTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true,
+              "isMultiSelect": true
+            },
+            {
+              "name": "startDate",
+              "label": "Testing Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Testing Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Testing Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Testing End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Testing End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Testing End Date must be greater than the Testing Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Testing End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geothermal-report-production": {
+      "steps": [
+        {
+          "title": "Lodge a Geothermal Report - Production",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[authorizedHolder] - [title] GEOTHERMAL PRODUCTION REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "placeholder": "e.g. ALL QUEENSLAND, BOWEN BASIN, BIG HILL PROJECT, FAIR GULLY FIELD, PL 1",
+              "label": "Coverage Of Report",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geothermal-report-production-testing": {
+      "steps": [
+        {
+          "title": "Lodge a Geothermal Report - Production Testing",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [siteName] - GEOTHERMAL PRODUCTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true,
+              "isMultiSelect": true
+            },
+            {
+              "name": "startDate",
+              "label": "Testing Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Testing Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Testing Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Testing End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Testing End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Testing End Date must be greater than the Testing Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Testing End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/greenhouse-gas-report-injection": {
+      "steps": [
+        {
+          "title": "Lodge a Greenhouse Gas Report - Injection",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] - [siteName] - GEOTHERMAL PRODUCTION TESTING REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true,
+              "isMultiSelect": true
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/greenhouse-gas-report-storage-capacity": {
+      "steps": [
+        {
+          "title": "Lodge a Greenhouse Gas Report - Storage Capacity",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] GREENHOUSE GAS STORAGE CAPACITY REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/greenhouse-gas-report-storage-injection": {
+      "steps": [
+        {
+          "title": "Lodge a Greenhouse Gas Report - Storage Injection",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] GREENHOUSE GAS STORAGE INJECTION REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/mine-plan-lodgement": {
+      "steps": [
+        {
+          "title": "Lodge a Mine Working Plan",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] MINE PLAN LODGEMENT AS AT [reportDate]",
+              "viewLabel": "Title of the Report",
+              "placeholder": "e.g. Cannington Mine",
+              "label": "Mine Name",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/survey-plan": {
+      "steps": [
+        {
+          "title": "Lodge a Survey plan",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "What is in the title plate of the plan? e.g. PWL of Boonah 222 or Survey of Mining Lease 222",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": false,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": false,
+              "isMultiSelect": true
+            },
+            {
+              "name": "startDate",
+              "label": "Survey Completion Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Survey Completion Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Survey Completion Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Signature Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Signature Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Signature Date must be greater than the Survey Completion Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Signature Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-final-relinquishment": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Final Relinquishment (MDL)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "e.g. EPM123, Project Name, final relinquishment report for period ending 28-04-2020",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-mineral-associated-water": {
+      "steps": [
+        {
+          "title": "Lodge a Water Report - Mineral Associated Water",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] MINERAL ASSOCIATED WATER TAKE REPORT FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project/Mine Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine, Cannington Mine",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the volume of water taken and from which basin taken.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-cumulative-water-production": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Cumulative Water Production",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "PL123, cumulative water production report for period ending 28-04-2020",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe fluid volumes oil and gas.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-field-information": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Field Information",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-infrastructure": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Infrastructure",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-non-associated-water": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Non-Associated Water",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] PETROLEUM NON-ASSOCIATED WATER TAKE REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/water-report-performance-review": {
+      "steps": [
+        {
+          "title": "Lodge a Water Report - Performance Review",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] WATER PERFORMANCE REVIEW FOR PERIOD [startDate] TO [endDate]",
+              "viewLabel": "Title of the Report",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine, Cannington Mine",
+              "label": "Project/Mine Name",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The End Date must be greater than the Start Date"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "waterLicenceNumber",
+              "label": "Water Licence Number",
+              "subLabelAtTop": "Please enter the Water Licence Number",
+              "type": "text",
+              "value": "",
+              "min": 5,
+              "max": 256,
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Water Licence is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "params": [
+                      1,
+                      "The Water Licence Number cannot be less than 1 character"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Water Licence Number can not be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pa-21A": {
+      "steps": [
+        {
+          "title": "Lodge a PA-21A Notice of Intention to carry out seismic survey or scientific or technical survey",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title] NOTICE OF INTENT TO CARRY OUT SEISMIC SURVEY OR SCIENTIFIC OR TECHINCAL SURVEY (PA-21A) [reportDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Survey Name",
+              "placeholder": "e.g. New Royal 3D, Bennett 2D, Cloncurry Airborne Geophysical Survey",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the intended survey including the method, target basins or features, planned activities, the extent of the survey, etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pa-22A": {
+      "steps": [
+        {
+          "title": "Lodge a PA-22A Notice of Completion of seismic survey or scientific or technical survey",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[surveyTitle] NOTICE OF COMPLETION OF SEISMIC SURVEY OR SCIENTIFIC OR TECHINCAL SURVEY (PA-22A) [reportDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "e.g. ATP123, 2019 Brunswick 2D seismic survey, notice of completion",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the survey, including methods, activities, target basin, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pm-1-2013": {
+      "steps": [
+        {
+          "title": "Lodge a PM 1/2013 Notification of geophysical survey",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title] - NOTICE OF INTENT TO CARRY OUT GEOPHYSICAL SURVEY (PM 1-2013) [reportDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Survey Name",
+              "placeholder": "e.g. New Royal 3D, Bennett 2D, Cloncurry Airborne Geophysical Survey",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pa-42": {
+      "steps": [
+        {
+          "title": "Lodge a PA-42 Notice of intention to convert a petroleum well to a water observation bore or water supply bore",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[siteName]  NOTICE OF INTENTION TO CONVERT A PETROLEUM WELL TO A WATER OBSERVATION BORE OR WATER SUPPLY BORE (PA-42) [reportDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/wra-05A": {
+      "steps": [
+        {
+          "title": "Lodge a WRA-05A Notice of completion of conversion of petroleum well to water supply bore or water observation bore",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [operator] [siteName]  NOTICE OF COMPLETION OF CONVERSION OF PETROLEUM WELL TO WATER SUPPLY BORE OR WATER OBSERVATION BORE (WRA-05A) - [reportDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/mmol-44": {
+      "steps": [
+        {
+          "title": "Lodge a MMOL-44 Notice of decommissioning a well, water observation bore, water monitoring bore or water supply bore",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[siteName] NOTICE OF DECOMMISION (MMOL-44) [reportDate]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true,
+              "isMultiSelect": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pggd-01": {
+      "steps": [
+        {
+          "title": "PGGD-01 Notice of intention to drill a petroleum well or bore",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "boreholeCreate",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Upload Notice of Intention",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "Notice of Intention",
+              "type": "component",
+              "values": {
+                "earthScienceData": {
+                  "readOnly": true,
+                  "value": "http://linked.data.gov.au/def/earth-science-data-category/drilling-engineering"
+                },
+                "title": {
+                  "readOnly": true,
+                  "value": "Notice of Intention"
+                },
+                "description": {
+                  "readOnly": true,
+                  "value": "Notice of Intention"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pggd-02": {
+      "steps": [
+        {
+          "title": "PGGD-02 Notice of completion, alteration or abandonment of a petroleum well or bore",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "boreholeAlteration",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Upload Notice of Completion, Alteration or Abandonment",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "Notice of Completion, Alteration or Abandonment",
+              "type": "component",
+              "values": {
+                "earthScienceData": {
+                  "readOnly": true,
+                  "value": "http://linked.data.gov.au/def/earth-science-data-category/drilling-engineering"
+                },
+                "title": {
+                  "readOnly": true,
+                  "value": "Notice of Completion, Alteration or Abandonment"
+                },
+                "description": {
+                  "readOnly": true,
+                  "value": ""
+                }
+              }
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pggd-03": {
+      "steps": [
+        {
+          "title": "PGGD-03 Notice of intention to carry out hydraulic fracturing activities",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "boreholeFracturing",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Upload Proposed Fluid Composition",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "Proposed Fluid Composition",
+              "isRequired": true,
+              "type": "component",
+              "values": {
+                "earthScienceData": {
+                  "readOnly": true,
+                  "value": "http://linked.data.gov.au/def/earth-science-data-category/reservoir-engineering"
+                },
+                "title": {
+                  "readOnly": true,
+                  "value": "Proposed Fluid Composition"
+                },
+                "description": {
+                  "readOnly": true,
+                  "value": "Proposed Fluid Composition"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/pggd-04": {
+      "steps": [
+        {
+          "title": "PGGD-04 Notice of completion of hydraulic fracturing activities",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "boreholeFracturingCompletion",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Upload Actual Fluid Composition",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "Actual Fluid Composition",
+              "infoText": "If 'Hydraulic fracturing abandoned' or 'Hydraulic fracturing related events' is selected then 'Actual Fluid Composition' document is not required to be lodged.",
+              "type": "component",
+              "isRequired": true,
+              "values": {
+                "earthScienceData": {
+                  "readOnly": true,
+                  "value": "http://linked.data.gov.au/def/earth-science-data-category/reservoir-engineering"
+                },
+                "title": {
+                  "readOnly": true,
+                  "value": "Actual Fluid Composition"
+                },
+                "description": {
+                  "readOnly": true,
+                  "value": "Actual Fluid Composition"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/any-other-report": {
+      "steps": [
+        {
+          "title": "Lodge a Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title of the Report",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": false,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "survey",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "nullable",
+                    "params": [
+                      ""
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "nullable",
+                    "params": [
+                      ""
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/collaborative-exploration-initiative-proposals": {
+      "steps": [
+        {
+          "title": "Lodge a Collaborative Exploration Initiative Proposal",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "COLLABORATIVE EXPLORATION INITIATIVE [title] - [permit] PROPOSAL",
+              "viewLabel": "Title of the Report",
+              "label": "ROUND # - CEI# PROJECT NAME - CEI ACTIVITY",
+              "placeholder": "e.g. Round 2 - CEI0027 ERNEST HENRY SOUTH PROJECT - MIMDAS SURVEY",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Provide a summary of the initiative, collaboration and proposed activity for the project",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this proposal",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Proposal Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Proposal Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "survey",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "borehole",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/collaborative-exploration-initiative-final": {
+      "steps": [
+        {
+          "title": "Lodge a Final Report for a Collaborative Exploration Initiative",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "COLLABORATIVE EXPLORATION INITIATIVE [title] - [permit] FINAL REPORT",
+              "viewLabel": "Title of the Report",
+              "label": "ROUND # - CEI# PROJECT NAME - CEI ACTIVITY",
+              "placeholder": "e.g. Round 2 : CEI0027 ERNEST HENRY SOUTH PROJECT - MIMDAS SURVEY",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Provide a summary of the initiative, collaboration and proposed activity for the project",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "survey",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "borehole",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/collaborative-drilling-initiative-final": {
+      "steps": [
+        {
+          "title": "Lodge a Final Report for a Collaborative Drilling Initiative",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Project name, collaborative drilling initiative final report",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Provide a summary of the initiative, collaboration and proposed activity for the project",
+              "type": "textArea"
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "survey",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "borehole",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/commissioned-industry-study-or-report": {
+      "steps": [
+        {
+          "title": "Lodge a Commissioned Industry Study or Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc ",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "survey",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/departmental-drilling": {
+      "steps": [
+        {
+          "title": "Lodge a Departmental Drilling Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the results of the drilling, methods used, and target basins, formations, or rock units",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": true
+            },
+            {
+              "type": "calender",
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geological-survey-of-queensland-publication": {
+      "steps": [
+        {
+          "title": "Lodge a Geological Survey of Queensland Publication",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Publication",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the publication and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc ",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this publication",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Publication Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/geological-survey-of-queensland-record": {
+      "steps": [
+        {
+          "title": "Lodge a Geological Survey of Queensland Record",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "GSQ RECORD [title]",
+              "viewLabel": "Title of the Report",
+              "label": "Year - Volume Number - Title",
+              "placeholder": "e.g. 2021 - VOLUME 01 - Summary of Results NWQ geochemistry sampling campaign",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this record",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-other": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Other",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "e.g  Queensland Government Mining Journal (QGMJ), Vol. 116, No. 3, 2018",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": false
+            },
+            {
+              "type": "calender",
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/petroleum-report-other": {
+      "steps": [
+        {
+          "title": "Lodge a Petroleum Report - Other",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": false
+            },
+            {
+              "type": "calender",
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/presentation": {
+      "steps": [
+        {
+          "title": "Lodge a Presentation",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Presentation",
+              "placeholder": "e.g  Queensland Government Mining Journal (QGMJ), Vol. 116, No. 3, 2018",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the presentation, including a summary of significant results or messages, conclusions and any areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this presentation",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/queensland-government-mining-journal": {
+      "steps": [
+        {
+          "title": "Lodge a Queensland Government Mining Journal",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents and key topics of the journal and its component articles.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/technical-report": {
+      "steps": [
+        {
+          "title": "Lodge a Technical Report",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "readOnly": true,
+              "label": "Title of the Report",
+              "placeholder": "Project name, technical report, purpose",
+              "type": "component"
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": false,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "survey",
+              "isRequired": false
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "nullable",
+                    "params": [
+                      ""
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "calender",
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "nullable",
+                    "params": [
+                      ""
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": false
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/water-report-other": {
+      "steps": [
+        {
+          "title": "Lodge a Water Report - Other",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[title]",
+              "viewLabel": "Title of the Report",
+              "label": "Title of the Report",
+              "placeholder": "Title may include permits, boreholes, project or mine name, operators, activity names, report type, and the period from and to",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe the contents of the report and its associated documents, including a summary of activities, significant results, conclusions, main methods used, areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": false,
+              "populateOwner": false
+            },
+            {
+              "type": "text",
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              },
+              "subLabelAtTop": "Please enter the name of the person who has authored this report"
+            },
+            {
+              "type": "component",
+              "name": "borehole",
+              "isRequired": false
+            },
+            {
+              "type": "calender",
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "nullable",
+                    "params": [
+                      ""
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "type": "calender",
+              "label": "Report Period End Date",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "nullable",
+                    "params": [
+                      ""
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is invalid"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "text",
+              "name": "waterLicenceNumber",
+              "label": "Water Licence Number",
+              "subLabelAtTop": "Please enter the Water Licence Number",
+              "value": "",
+              "min": 5,
+              "max": 256,
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Water Licence is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "params": [
+                      1,
+                      "The Water Licence Number cannot be less than 1 character"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Water Licence Number can not be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            }
+          ]
+        },
+        {
+          "name": "Document Uploads",
+          "title": "Documents and Data",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-annual-ml": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Annual Activity (ML)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] ANNUAL ACTIVITY REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the report for a coal or oil shale mining lease including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-final-higher-tenure": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Final (Grant of higher tenure)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] FINAL REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the final report where higher tenure has been granted for the overlying area including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "http://linked.data.gov.au/def/georesource-report/permit-report-surrender-higher-tenure": {
+      "steps": [
+        {
+          "title": "Lodge a Coal or Mineral Permit Report - Surrender (Grant of higher tenure)",
+          "name": "Report Details",
+          "inputs": [
+            {
+              "name": "title",
+              "format": "[permit] [title] SURRENDER REPORT FOR PERIOD ENDING [endDate]",
+              "viewLabel": "Title of the Report",
+              "label": "Project Name",
+              "placeholder": "e.g. Norwich Park, Monto West, Ernestine",
+              "type": "component",
+              "isRequired": false
+            },
+            {
+              "name": "alias",
+              "label": "Aliases",
+              "type": "component",
+              "readOnly": true
+            },
+            {
+              "name": "description",
+              "viewLabel": "Description",
+              "label": "Report Description",
+              "placeholder": "Describe a summary of the surrender report where higher tenure has been granted for the overlying area including activities, significant results, conclusions, metals/minerals/deposit type, main methods used, target areas of interest etc.",
+              "type": "textArea",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "matches",
+                    "isComplex": true,
+                    "params": [
+                      "/^[0-9A-Za-z- ./,]+$/",
+                      "Description cannot include non-standard characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "permit",
+              "isRequired": true,
+              "populateOwner": true
+            },
+            {
+              "name": "reportAuthor",
+              "label": "Report Author",
+              "subLabelAtTop": "Please enter the name of the person who has authored this report",
+              "type": "text",
+              "validations": {
+                "type": "string",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Author is required"
+                    ]
+                  },
+                  {
+                    "name": "max",
+                    "params": [
+                      256,
+                      "The Report Author cannot be more than 256 characters"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "startDate",
+              "label": "Report Period Start Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period Start Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "endDate",
+              "label": "Report Period End Date",
+              "type": "calender",
+              "validations": {
+                "type": "date",
+                "rules": [
+                  {
+                    "name": "required",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  },
+                  {
+                    "name": "min",
+                    "isComplex": true,
+                    "params": [
+                      "yup.ref('startDate')",
+                      "The Report Period End Date must be greater than the Report Period Start Date"
+                    ]
+                  },
+                  {
+                    "name": "typeError",
+                    "params": [
+                      "Report Period End Date is required"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "component",
+              "name": "commodity",
+              "isRequired": true
+            },
+            {
+              "type": "component",
+              "name": "earthScienceData",
+              "isRequired": true
+            },
+            {
+              "name": "detail",
+              "label": "Details",
+              "type": "component",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "title": "Documents and Data",
+          "name": "Document Uploads",
+          "inputs": [
+            {
+              "name": "associatedDocuments",
+              "label": "associated document",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "reportingTemplateDocuments",
+              "type": "component",
+              "isRequired": true
+            },
+            {
+              "name": "spatialDocuments",
+              "type": "component",
+              "isRequired": false
+            }
+          ]
+        },
+        {
+          "title": "Review and Submit",
+          "name": "Review & Submit",
+          "inputs": [
+            {
+              "name": "review",
+              "type": "component",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Intent:
Adding templates for legacy PROD and RESERV reports (for use in internal lodgement portal).
Restricting multi-select of permits for well based reports (e.g. WCR, WAR) and reports that may pertain to a well-set in a single permit (e.g. Well Prod Testing, Geothem Inj Testing).

I don't trust my own JSON skills. please review carefully