### PR TITLE
Update openFileDateConfig.json

### DIFF
--- a/scripts/openFileDateConfig.json
+++ b/scripts/openFileDateConfig.json
@@ -1,7 +1,7 @@
 {
   "version": "0.7",
-  "Last updated date": "25/05/2022",
-  "Last updated by": "D Armstrong, GSQ",
+  "Last updated date": "20/04/2023",
+  "Last updated by": "B Talebi, GSQ",
   "reportCalculations": [
     {
       "reportType": "http://linked.data.gov.au/def/georesource-report/geophysical-survey-report-acquisition",
@@ -109,7 +109,7 @@
           "period": {
             "years": 5,
             "months": 0,
-            "days": 0
+            "days": 1
           }
         },
         {
@@ -117,9 +117,9 @@
             "http://linked.data.gov.au/def/qld-resource-permit/ExplorationPermitGeothermal"
           ],
           "period": {
-            "years": 2,
+            "years": 3,
             "months": 0,
-            "days": 0
+            "days": 1
           }
         }
       ]


### PR DESCRIPTION
Lodgement Portal - Geothermal Report - Production Testing - EPG/GL - currently setup open file dates are incorrect and must be updated to reflect the correct open filing dates under Geothermal Energy Regulations 2022 – Schedule 3 – Confidentiality periods for required information, Section 37(1), as following:

- Geothermal Report - Production Testing (EPG), open file date should be 3 years, 1 day from the Testing End Date.
- Geothermal Report - Production Testing (GL), open file date should be 5 years, 1 day from the Testing End Date.

See https://itp-qld.atlassian.net/browse/SUP-135 for details.