### PR TITLE
Update openFileDateConfig.json

### DIFF
--- a/scripts/openFileDateConfig.json
+++ b/scripts/openFileDateConfig.json
@@ -306,7 +306,7 @@
       "calculations": [
         {
           "period": {
-            "years": 0,
+            "years": 10,
             "months": 6,
             "days": 1
           }
@@ -319,7 +319,7 @@
       "calculations": [
         {
           "period": {
-            "years": 0,
+            "years": 10,
             "months": 6,
             "days": 1
           }


### PR DESCRIPTION
Temporary change  - QAQC process requires pause to auto-releasing reports matured at time of submission. The value is arbitrary yet must be larger than current reporting template lifespan. 