### PR TITLE
Update reportTemplates.json

### DIFF
--- a/scripts/reportTemplates.json
+++ b/scripts/reportTemplates.json
@@ -12374,6 +12374,187 @@
 				}
 			]
 		},
+		"http://linked.data.gov.au/def/georesource-report/key-resource-area-report": {
+			"geoconfig": {
+				"primarysource": "spatial_file",
+				"permitRelationshipObject": "none"
+			},
+			"steps": [
+				{
+					"title": "Lodge a Key Resource Area Report",
+					"subTitle": "Report Details",
+					"name": "metadata",
+					"inputs": [
+						{
+							"name": "title",
+							"format": "[title]",
+							"viewLabel": "Title of the Report",
+							"label": "Title of the Report",
+							"placeholder": "e.g. Key Resource Area 1 - Ravensbourne",
+							"type": "component",
+							"isRequired": true
+						},
+						{
+							"name": "alias",
+							"label": "Aliases",
+							"type": "component",
+							"readOnly": true
+						},
+						{
+							"name": "description",
+							"viewLabel": "Description",
+							"label": "Report Description",
+							"placeholder": "Describe the contents of the report and its associated documents, e.g., The location, resource description, significance and other details describing KRA 1 - Ravensbourne.",
+							"subLabelAtTop": "Allowable characters are alphanumeric A-Z, a-z and 0-9 ; and standard punctuation [].,!@?'$%()*=-_–~;:/&+\"\\ ; all new lines must be separated by a double line break (double enter). <br /> For guidance and troubleshooting on allowable character inputs <a href='https://github.com/geological-survey-of-queensland/gsq-lodgement-portal#character-limitations' target='_blank'>click here</a> .",
+							"type": "textArea",
+							"validations": {
+								"type": "string",
+								"rules": [
+									{
+										"name": "matches",
+										"isComplex": true,
+										"params": [
+											"/^[0-9A-Za-z .,!@?'$%()[\\]*=\\-_—–~;:/&+\\\"\\\\\\s]+$/",
+											"Description cannot include non-standard characters"
+										]
+									}
+								]
+							}
+						},
+						{
+							"type": "component",
+							"name": "permit",
+							"isRequired": false,
+							"populateOwner": true
+						},
+						{
+							"name": "reportAuthor",
+							"label": "Report Author",
+							"subLabelAtTop": "Please enter the name of the person who has authored this report",
+							"type": "text",
+							"validations": {
+								"type": "string",
+								"rules": [
+									{
+										"name": "required",
+										"params": [
+											"Report Author is required"
+										]
+									},
+									{
+										"name": "max",
+										"params": [
+											256,
+											"The Report Author cannot be more than 256 characters"
+										]
+									}
+								]
+							}
+						},
+						{
+							"type": "component",
+							"name": "borehole",
+							"isRequired": false
+						},
+						{
+							"type": "component",
+							"name": "survey",
+							"isRequired": false
+						},
+						{
+							"name": "startDate",
+							"label": "Report Period Start Date",
+							"type": "calender",
+							"validations": {
+								"type": "date",
+								"rules": [
+									{
+										"name": "nullable",
+										"params": [
+											""
+										]
+									},
+									{
+										"name": "typeError",
+										"params": [
+											"Report Period Start Date is invalid"
+										]
+									}
+								]
+							}
+						},
+						{
+							"type": "calender",
+							"name": "endDate",
+							"label": "Report Period End Date",
+							"validations": {
+								"type": "date",
+								"rules": [
+									{
+										"name": "nullable",
+										"params": [
+											""
+										]
+									},
+									{
+										"name": "typeError",
+										"params": [
+											"Report Period End Date is invalid"
+										]
+									}
+								]
+							}
+						},
+						{
+							"type": "component",
+							"name": "commodity",
+							"isRequired": false
+						},
+						{
+							"type": "component",
+							"name": "earthScienceData",
+							"isRequired": true
+						},
+						{
+							"type": "component",
+							"label": "Access Rights",
+							"name": "accessRight",
+							"readOnly": true
+						}
+					]
+				},
+				{
+					"title": "Documents and Data",
+					"subTitle": "Document Uploads",
+					"name": "document",
+					"inputs": [
+						{
+							"name": "associatedDocuments",
+							"label": "associated document",
+							"type": "component",
+							"isRequired": true
+						},
+						{
+							"name": "spatialDocuments",
+							"type": "component",
+							"isRequired": false
+						}
+					]
+				},
+				{
+					"title": "Review and Submit",
+					"subTitle": "Review & Submit",
+					"name": "submit",
+					"inputs": [
+						{
+							"name": "review",
+							"type": "component",
+							"isRequired": true
+						}
+					]
+				}
+			]
+		},
 		"http://linked.data.gov.au/def/georesource-report/water-report-other": {
 			"geoconfig": {
 				"primarysource": "permit",


### PR DESCRIPTION
Adding KRA Reports to valid report types. In conjunction with https://github.com/geological-survey-of-queensland/vocabularies/pull/539 

Creating "Key Resource Area Report" report type, after "Technical Report", to create a report type facet in ODP. Not for general distribution to the public report type list (i.e. internal use only).